### PR TITLE
Highcharts.php | Skripte nur noch im Dashboard enqueuen

### DIFF
--- a/includes/Analytics.php
+++ b/includes/Analytics.php
@@ -11,7 +11,7 @@ class Analytics
 {
     public function __construct()
     {
-        $this->highcharts = new Highcharts();
+        
     }
 
     public static function getDate()
@@ -61,6 +61,7 @@ class Analytics
         if ($ready_check === false) {
             return printf(__('It might take a few days until personal statistics for your website ( %1$s ) are displayed within your dashboard.', 'rrze-statistik'), $site) . '</strong><br />';
         } else {
+            $this->highcharts = new Highcharts();
             return $this->highcharts->lineplot($container);
         };
     }

--- a/includes/Analytics.php
+++ b/includes/Analytics.php
@@ -100,13 +100,21 @@ class Analytics
             return  __('It might take a few weeks until the summary is displayed on your dashboard.', 'rrze-statistik') . '</strong><br />';
         } else {
             $data_chunks = array_chunk($data, 10);
-            $top_url = $data_chunks[0];
-            $top_images = $data_chunks[1];
+            
+            //if data_chunks is set, create the table
 
-            $table1 = Self::getTwoDimensionalHtmlTable($top_url, 0, 1, __('Hits', 'rrze-statistik'), __('Sites', 'rrze-statistik'));
-            $table2 = Self::getTwoDimensionalHtmlTable($top_images, 0, 1, __('Hits', 'rrze-statistik'), __('Images', 'rrze-statistik'));
+            if(array_key_exists(0, $data_chunks)){
+                $top_url = $data_chunks[0];
+                $table1 = Self::getTwoDimensionalHtmlTable($top_url, 0, 1, __('Hits', 'rrze-statistik'), __('Sites', 'rrze-statistik'));
+                $output = $table1;
+            }
+            if(array_key_exists(1, $data_chunks)){
+                $top_images = $data_chunks[1];
+                $table2 = Self::getTwoDimensionalHtmlTable($top_images, 0, 1, __('Hits', 'rrze-statistik'), __('Images', 'rrze-statistik'));
+                $output .= $table2;
+            }
 
-            return $table1 . $table2;
+            return $output;
         }
     }
 

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -12,6 +12,7 @@ class Dashboard
     public function __construct()
     {
         add_action('wp_dashboard_setup', [$this, 'add_rrze_statistik_dashboard_widget']);
+
     }
 
     /**

--- a/includes/Highcharts.php
+++ b/includes/Highcharts.php
@@ -63,7 +63,6 @@ class Highcharts
 
     public function loadHighcharts()
     {
-        add_action('wp_enqueue_scripts', array($this, 'statistik_enqueue_script'));
         add_action('admin_enqueue_scripts', array($this, 'statistik_enqueue_script'));;
     }
 

--- a/includes/Highcharts.php
+++ b/includes/Highcharts.php
@@ -63,7 +63,7 @@ class Highcharts
 
     public function loadHighcharts()
     {
-        add_action('admin_enqueue_scripts', array($this, 'statistik_enqueue_script'));;
+        add_action('admin_enqueue_scripts', array($this, 'statistik_enqueue_script'));
     }
 
     /**

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -9,11 +9,10 @@ class Main
     public function __construct()
     {
         new Helper();
-        $highcharts = new Highcharts();
-        $highcharts->loadHighcharts();
-
         new Dashboard();
 
+        $highcharts = new Highcharts();
+        $highcharts->loadHighcharts();
         Cron::init();
     }
 }


### PR DESCRIPTION
Bugfix damit Inhaltsseiten Highcharts.js nicht mehr enqueuen

Änderung in
includes/Highcharts.php - Zeile 66 ( wp_enqueue_scripts ) entfernt.

// Im Plugin gibt es keinen Shortcode, deshalb nicht benötigt.
