### PR TITLE
v.1.1.5 - Fix der Scripteinbindung

### DIFF
--- a/includes/Highcharts.php
+++ b/includes/Highcharts.php
@@ -11,30 +11,37 @@ class Highcharts
 {
     public function __construct()
     {
-        $this->loadHighcharts();
+        add_action('admin_enqueue_scripts', array($this, 'statistik_register_script'));
     }
 
-    public function statistik_enqueue_script()
+    public function statistik_register_script($hook_suffix)
     {
-        wp_enqueue_style(
+
+        
+        wp_register_style(
             'highcharts-css',
             plugins_url('dist/highcharts.css', plugin()->getBasename()),
             array(),
             plugin()->getVersion(),
             'all'
         );
-        wp_enqueue_script(
+        wp_register_script(
             'index-js',
             plugins_url('dist/highchartsIndex.js', plugin()->getBasename()),
             array(),
             plugin()->getVersion(),
             true
         );
-    }
 
-    public function loadHighcharts()
-    {
-        add_action('admin_enqueue_scripts', array($this, 'statistik_enqueue_script'));
+            $screen = get_current_screen();
+            $screen_id = $screen->id ?? '';
+
+            if ($screen_id == "dashboard") {
+                wp_enqueue_script('highcharts-css');
+                wp_enqueue_script('index-js');
+            }
+
+
     }
 
     /**
@@ -53,7 +60,7 @@ class Highcharts
         } else {
             $logs_url = Analytics::retrieveSiteUrl('logs');
             return
-            '<figure class="rrze-statistik highcharts-figure">
+                '<figure class="rrze-statistik highcharts-figure">
             <div id="' . $container . '"></div>
             <p class="highcharts-description">' . Language::getLinechartDescription($container) . '</p><hr />
             <a href=' . $logs_url . '>' . __('Source: www.statistiken.rrze.fau.de', 'rrze-statistik') . '</a><hr />

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -12,8 +12,7 @@ class Main
         new Dashboard();
         new Data();
 
-        $highcharts = new Highcharts();
-        $highcharts->loadHighcharts();
+        new Highcharts();
         Cron::init();
     }
 }

--- a/rrze-statistik.php
+++ b/rrze-statistik.php
@@ -4,7 +4,7 @@
 Plugin Name:     RRZE Statistics
 Plugin URI:      https://github.com/rrze-webteam/rrze-statistik
 Description:     Displays monthly statistics from https://statistiken.rrze.fau.de within your Dashboard.
-Version:         1.1.4
+Version:         1.1.5
 Author:          RRZE Webteam
 Author URI:      https://blogs.fau.de/webworking/
 License:         GNU General Public License v2
@@ -18,7 +18,7 @@ defined('ABSPATH') || exit;
 
 use RRZE\Statistik\Main;
 
-const RRZE_HIGHCHARTS_VERSION = '9.3.3';
+const RRZE_HIGHCHARTS_VERSION = '10.1.0';
 
 const RRZE_PHP_VERSION = '7.4';
 const RRZE_WP_VERSION = '5.8';


### PR DESCRIPTION
Scripte werden mit diesem Update nur noch auf dem Dashboard eingebunden. Vorher wurde der Script auch im Customizer geladen, was eine Konsolenausgabe mit sich brachte..